### PR TITLE
Починить полноэкранный режим в iframe

### DIFF
--- a/ftml/src/render/html/element/iframe.rs
+++ b/ftml/src/render/html/element/iframe.rs
@@ -27,8 +27,7 @@ pub fn render_iframe(ctx: &mut HtmlContext, url: &str, attributes: &AttributeMap
     ctx.html().iframe().attr(attr!(
         "src" => url,
         "sandbox" => "allow-scripts allow-top-navigation allow-popups allow-modals",
-        "allow" => "fullscreen",
-        "allowfullscreen" => "allowfullscreen",
+        "allowfullscreen" => "",
         "crossorigin";;
         attributes
     ));


### PR DESCRIPTION
Несмотря на документацию mozila, единственным стабильно рабочим разрешением айфрейму выходить в полноэкранный режим является allowfullscreen атрибут