### PR TITLE
Fix page title input being wider than the rest of the page

### DIFF
--- a/static/scp-base.css
+++ b/static/scp-base.css
@@ -1569,7 +1569,7 @@ td {
     }
  
     #edit-page-title {
-        max-width: 90%;
+        width: 90%;
     }
  
     .content-panel.left-column, .content-panel.right-column {


### PR DESCRIPTION
In mobile view, the `max-width` property of `#edit-page-title` was changing the size of the element to match the 90% restriction, however the empty 10% space was still left there, thus creating a margin of empty space to the right of the main `<html>` element (tested on Google Chrome's 375x667 iPhone SE preset). Using `width`, however, seems to fix the issue.

Here's an example of the layout as it is now (notice the `<td>` going beyond the end of `#page-options-container`):
![Without the fix](https://github.com/user-attachments/assets/4b9ced2e-9108-438b-ba7b-dc807eed7239)
Here's the same layout with the proposed fix applied:
![With the fix](https://github.com/user-attachments/assets/5f14fcf9-89d4-461e-a252-495038b197a9)