### PR TITLE
Обернуть текст внутри #login-status в <span>

### DIFF
--- a/web/js/entrypoints/page-login-status.tsx
+++ b/web/js/entrypoints/page-login-status.tsx
@@ -53,7 +53,7 @@ class PageLoginStatus extends Component<Props, State> {
         if (user.type === 'anonymous') {
             return (
                 <>
-                    <a className="login-status-create-account btn" href="/system:join">Создать учётную запись</a> или <a className="login-status-sign-in btn btn-primary" href={`/-/login?to=${encodeURIComponent(window.location.href)}`}>Вход</a>
+                    <a className="login-status-create-account btn" href="/system:join">Создать учётную запись</a> <span>или</span> <a className="login-status-sign-in btn btn-primary" href={`/-/login?to=${encodeURIComponent(window.location.href)}`}>Вход</a>
                 </>
             );
         } else {


### PR DESCRIPTION
Позволяет из кода CSS выбирать строчку текста "или", расположенную между ссылками на страницу входа, если пользователь не вошёл в аккаунт. Чинит [Bedrock](https://scpfoundation.net/theme:bedrock) и следующие производные темы:
* [Basalt](https://scpfoundation.net/theme:basalt)
* [ADMONITION](https://scpfoundation.net/theme:admo)
* [SCP: 5K](https://scpfoundation.net/theme:5k)
* [Eigenmachine](https://scpfoundation.net/theme:eigenmachine)