### PR TITLE
Add `.footer-wikiwalk-nav` to base CSS

### DIFF
--- a/static/scp-base.css
+++ b/static/scp-base.css
@@ -376,6 +376,10 @@ div.curved {
 iframe.scpnet-interwiki-frame, div.scpnet-interwiki-wrapper {
      width: 18em;
 }
+
+#page-content div.footer-wikiwalk-nav {
+    font-size: 90%;
+}
  
 /*
     SCP Sigma 9


### PR DESCRIPTION
Добавляет новый стиль для блока `footer-wikiwalk-nav`, использующегося для навигации между объектами, меняя размер шрифта на 90%, как это у нас исторически делалось через `[[size 90%]]`.