### PR TITLE
Prevent spaces from collapsing between `@@ @@`

### DIFF
--- a/static/scp-base.css
+++ b/static/scp-base.css
@@ -380,6 +380,11 @@ div.curved {
 iframe.scpnet-interwiki-frame, div.scpnet-interwiki-wrapper {
      width: 18em;
 }
+
+/* Stop the spaces between `@@` from collapsing, just like on WikiDot */
+.wj-raw {
+    white-space: pre-wrap;
+}
  
 /*
     SCP Sigma 9


### PR DESCRIPTION
This PR adds a new rule `.wj-raw` to `scp-base.css` that basically restores the WD behaviour of the `@@ @@` syntax.

If accepted, this would allow translators to not resort to the usage of `[[span style="white-space: pre-wrap;"]] [[/span]]` whenever they encounter `@@ @@` that is used not for newlines, but for preserving the extra spaces.