### PR TITLE
Cancels PR #300

### DIFF
--- a/renderer/html.py
+++ b/renderer/html.py
@@ -9,7 +9,7 @@ def get_html_injected_code(html_id: str) -> str:
         function doFrame() {
             const body = document.body;
             const html = document.documentElement;
-            const height = Math.max(body && body.scrollHeight, body && body.offsetHeight, html.offsetHeight, body && body.getBoundingClientRect().height, html.scrollHeight);
+            const height = Math.max(body && body.scrollHeight, body && body.offsetHeight, html.offsetHeight, body && body.getBoundingClientRect().height);
             window.requestAnimationFrame(doFrame);
             if (lastHeight !== height) {
                 parent.postMessage({type: 'iframe-change-height', payload: { height, id: %s } }, '*');


### PR DESCRIPTION
Ну, в общем, такие дела. Coverage оказался недостаточным, оказалось, что у этого есть один довольно неприятный баг.

Несмотря на то, что сам PR #300 действительно исправлял проблему с тряской элементов при изменении размера, достигалось это, как выяснилось, невозможностью iframe'ов уменьшаться, что является крайне нежелательным результатом. Из-за этого при уменьшении содержимого iframe'а сам элемент не менял свой размер.

Данный PR откатывает это изменение.

_Не убивайте пожалуйста 👉👈_