### PR TITLE
fixed incorrect footnote behaviour on mobile

### DIFF
--- a/web/js/articles/footnote.ts
+++ b/web/js/articles/footnote.ts
@@ -96,6 +96,10 @@ export function makeFootnote(node: HTMLElement) {
     footnoteContent.innerHTML = ''
   }
 
+  node.addEventListener("click", event => {
+    if (!matchMedia("(hover: hover)").matches) event.preventDefault();
+  });
+
   node.addEventListener('mouseover', e => {
     enableAndPosition(e.clientX, e.clientY)
   })


### PR DESCRIPTION
Фиксит #115 

Поведение теперь плюс-минус идентично викидотовскому, пускай там переход по сноскам на мобилках не работал из-за жуткого бага.