### PR TITLE
Fix %r date format using timestamps instead of seconds

### DIFF
--- a/web/js/util/date-format.ts
+++ b/web/js/util/date-format.ts
@@ -75,7 +75,7 @@ export default function formatDate(date: Date, format: string = '%H:%M %d.%m.%Y'
   var s = format
   s = s
     .replace(/%h/g, '%b')
-    .replace(/%r/g, '%I:%M:%s %p')
+    .replace(/%r/g, '%I:%M:%S %p')
     .replace(/%R/g, '%H:%M')
     .replace(/%a/g, days[dayWeekU])
     .replace(/%d/g, padString('00', date.getDate().toString()))


### PR DESCRIPTION
Убирает проблему, когда `%r` превращается в `07:05:1044072300 AM` вместо `07:05:00 AM`. Формально исправляет одно из несоответствий в #327 